### PR TITLE
set GEOTIFF_CSV_DATA_DIR

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,6 +13,7 @@ cmake -G "NMake Makefiles" ^
       -D TIFF_NAMES=libtiff_i ^
       -D PROJ4_NAMES=proj_i ^
       -D JPEG_NAMES=libjpeg ^
+	  -D GEOTIFF_CSV_DATA_DIR=%LIBRARY_PREFIX%\Library\share\epsg_csv
       %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,7 +13,7 @@ cmake -G "NMake Makefiles" ^
       -D TIFF_NAMES=libtiff_i ^
       -D PROJ4_NAMES=proj_i ^
       -D JPEG_NAMES=libjpeg ^
-	  -D GEOTIFF_CSV_DATA_DIR=%LIBRARY_PREFIX%\Library\share\epsg_csv
+      -D GEOTIFF_CSV_DATA_DIR=%LIBRARY_PREFIX%\share\epsg_csv ^
       %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,7 @@ cmake -D CMAKE_PREFIX_PATH=$PREFIX \
       -D WITH_ZLIB=ON \
       -D WITH_JPEG=ON \
       -D WITH_TIFF=ON \
+	  -D GEOTIFF_CSV_DATA_DIR=$PREFIX/share/epsg_csv
       $SRC_DIR
 
 make -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,7 @@ cmake -D CMAKE_PREFIX_PATH=$PREFIX \
       -D WITH_ZLIB=ON \
       -D WITH_JPEG=ON \
       -D WITH_TIFF=ON \
-	  -D GEOTIFF_CSV_DATA_DIR=$PREFIX/share/epsg_csv
+      -D GEOTIFF_CSV_DATA_DIR=$PREFIX/share/epsg_csv \
       $SRC_DIR
 
 make -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ad87048adb91167b07f34974a8e53e4ec356494c29f1748de95252e8f81a5e6e
 
 build:
-  number: 1004
+  number: 1005
 
 requirements:
   build:


### PR DESCRIPTION
GEOTIFF_CSV_DATA_DIR needs to be set at compile time so libgeotiff can resolve EPSG files.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
