### PR TITLE
Rerender to try to fix windows linking issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,16 +98,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `geotiff` can be installed with:
+Once the `conda-forge` channel has been enabled, `geotiff` can be installed with `conda`:
 
 ```
 conda install geotiff
 ```
 
-It is possible to list all of the versions of `geotiff` available on your platform with:
+or with `mamba`:
+
+```
+mamba install geotiff
+```
+
+It is possible to list all of the versions of `geotiff` available on your platform with `conda`:
 
 ```
 conda search geotiff --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search geotiff --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search geotiff --channel conda-forge
+
+# List packages depending on `geotiff`:
+mamba repoquery whoneeds geotiff --channel conda-forge
+
+# List dependencies of `geotiff`:
+mamba repoquery depends geotiff --channel conda-forge
 ```
 
 
@@ -125,10 +150,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - cmake.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgeotiff


### PR DESCRIPTION
It appears the last render didn't successfully build for windows. See https://github.com/conda-forge/gdal-feedstock/issues/616 for details.